### PR TITLE
Remove HTTP configuration

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -3,8 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"net/http"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -23,7 +21,6 @@ func NewTfSplitPoliciesDataSource() datasource.DataSource {
 
 // TfSplitPoliciesDataSource defines the data source implementation.
 type TfSplitPoliciesDataSource struct {
-	client *http.Client
 }
 
 // TfSplitPoliciesDataSourceModel describes the data source data model.
@@ -68,23 +65,6 @@ func (d *TfSplitPoliciesDataSource) Schema(ctx context.Context, req datasource.S
 }
 
 func (d *TfSplitPoliciesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*http.Client)
-
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	d.client = client
 }
 
 func (d *TfSplitPoliciesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"net/http"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -40,14 +38,6 @@ func (p *TfSplitPoliciesProvider) Configure(ctx context.Context, req provider.Co
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Configuration values are now available.
-	// if data.Endpoint.IsNull() { /* ... */ }
-
-	// Example client configuration for data sources and resources
-	client := http.DefaultClient
-	resp.DataSourceData = client
-	resp.ResourceData = client
 }
 
 func (p *TfSplitPoliciesProvider) Resources(ctx context.Context) []func() resource.Resource {


### PR DESCRIPTION
We don't use remote data, so we can safely remove the HTTP config.