### PR TITLE
Rename provider to split-policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ documents that don't overflow then AWS-imposed limit of 6144 bytes. The chunk si
 ## Usage
 
 ```hcl
-data "tf-split-policies" "test" {
+data "split-policies" "test" {
   policies = ["one", "two", "three"]
   maximum_chunk_size = 6
 }

--- a/internal/provider/data_source_test.go
+++ b/internal/provider/data_source_test.go
@@ -11,7 +11,7 @@ func TestDataSourceEmpty(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      `data "tf-split-policies" "test" {}`,
+				Config:      `data "split-policies" "test" {}`,
 				ExpectError: regexp.MustCompile("The argument \"policies\" is required, but no definition was found."),
 			},
 		},
@@ -27,11 +27,11 @@ func TestSmallDataSourceOneChunk(t *testing.T) {
 			{
 				Config: testSmallDataSourceOneChunkConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.%", "1"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.0.#", "3"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.0.0", "one"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.0.1", "two"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.0.2", "three"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.%", "1"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.#", "3"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.0", "one"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.1", "two"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.2", "three"),
 				),
 			},
 		},
@@ -39,7 +39,7 @@ func TestSmallDataSourceOneChunk(t *testing.T) {
 }
 
 const testSmallDataSourceOneChunkConfig = `
-data "tf-split-policies" "test" {
+data "split-policies" "test" {
   policies = ["one", "two", "three"]
 }
 `
@@ -53,12 +53,12 @@ func TestSmallDataSourceManyChunks(t *testing.T) {
 			{
 				Config: testSmallDataSourceManyChunksConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.%", "2"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.0.#", "2"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.1.#", "1"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.0.0", "one"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.0.1", "two"),
-					resource.TestCheckResourceAttr("data.tf-split-policies.test", "chunks.1.0", "three"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.%", "2"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.#", "2"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.1.#", "1"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.0", "one"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.1", "two"),
+					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.1.0", "three"),
 				),
 			},
 		},
@@ -66,7 +66,7 @@ func TestSmallDataSourceManyChunks(t *testing.T) {
 }
 
 const testSmallDataSourceManyChunksConfig = `
-data "tf-split-policies" "test" {
+data "split-policies" "test" {
   policies = ["one", "two", "three"]
   maximum_chunk_size = 6
 }

--- a/internal/provider/hash_inputs.go
+++ b/internal/provider/hash_inputs.go
@@ -15,7 +15,7 @@ func hashInputs(data *TfSplitPoliciesDataSourceModel) (string, error) {
 	var hasher = sha1.New()
 	var err error
 
-	if _, err = hasher.Write([]byte("tf-split-policies")); err != nil {
+	if _, err = hasher.Write([]byte("split-policies")); err != nil {
 		return "", err
 	}
 

--- a/internal/provider/hash_inputs_test.go
+++ b/internal/provider/hash_inputs_test.go
@@ -26,7 +26,7 @@ func getTestInputs() *TfSplitPoliciesDataSourceModel {
 func TestHashInputs(t *testing.T) {
 	var value, err = hashInputs(getTestInputs())
 	assert.NoError(t, err)
-	if diff := cmp.Diff("6147455429151f8f85ddef8ff11cc2db51487778", value); diff != "" {
+	if diff := cmp.Diff("89160751b83d1e981c46598c914b50c870d141f3", value); diff != "" {
 		t.Errorf("Got invalid hash:\n%s", diff)
 	}
 }
@@ -34,7 +34,7 @@ func TestHashInputs(t *testing.T) {
 func TestEmptyHashInputs(t *testing.T) {
 	var value, err = hashInputs(getEmptyTestInputs())
 	assert.NoError(t, err)
-	if diff := cmp.Diff("17ac149523008b6a682017bc07987f0d06e4585b", value); diff != "" {
+	if diff := cmp.Diff("e7607a63a2af79a17a07d6aec52471436b72a363", value); diff != "" {
 		t.Errorf("Got invalid hash:\n%s", diff)
 	}
 }
@@ -45,7 +45,7 @@ func TestEnsureDifferentFromEmpty(t *testing.T) {
 
 	value2, err := hashInputs(getEmptyTestInputs())
 	assert.NoError(t, err)
-	
+
 	if value1 == value2 {
 		t.Errorf("The hash results are the same. Clearly something has gone wrong.")
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,7 +27,7 @@ func (p *TfSplitPoliciesProvider) Metadata(
 	_ context.Context,
 	_ provider.MetadataRequest,
 	resp *provider.MetadataResponse) {
-	resp.TypeName = "tf-split-policies"
+	resp.TypeName = "split-policies"
 	resp.Version = p.version
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -12,7 +12,7 @@ import (
 // CLI command executed to create a provider server to which the CLI can
 // reattach.
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"tf-split-policies": providerserver.NewProtocol6WithError(New("test")()),
+	"split-policies": providerserver.NewProtocol6WithError(New("test")()),
 }
 
 func testAccPreCheck(_ *testing.T) {


### PR DESCRIPTION
This change makes the provider name match the repository name.