### PR TITLE
Rename provider from split-policies to splitpolicies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/octoenergy/tf-split-policies
+module github.com/octoenergy/terraform-provider-splitpolicies
 
 go 1.19
 

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -15,7 +15,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ datasource.DataSource = &TfSplitPoliciesDataSource{}
 
-// NewTfSplitPoliciesDataSource creates a new tf-split-policies data source
+// NewTfSplitPoliciesDataSource creates a new tf-splitpolicies data source
 func NewTfSplitPoliciesDataSource() datasource.DataSource {
 	return &TfSplitPoliciesDataSource{}
 }

--- a/internal/provider/data_source_test.go
+++ b/internal/provider/data_source_test.go
@@ -11,7 +11,7 @@ func TestDataSourceEmpty(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      `data "split-policies" "test" {}`,
+				Config:      `data "splitpolicies" "test" {}`,
 				ExpectError: regexp.MustCompile("The argument \"policies\" is required, but no definition was found."),
 			},
 		},
@@ -27,11 +27,11 @@ func TestSmallDataSourceOneChunk(t *testing.T) {
 			{
 				Config: testSmallDataSourceOneChunkConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.%", "1"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.#", "3"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.0", "one"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.1", "two"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.2", "three"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.%", "1"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.0.#", "3"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.0.0", "one"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.0.1", "two"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.0.2", "three"),
 				),
 			},
 		},
@@ -39,7 +39,7 @@ func TestSmallDataSourceOneChunk(t *testing.T) {
 }
 
 const testSmallDataSourceOneChunkConfig = `
-data "split-policies" "test" {
+data "splitpolicies" "test" {
   policies = ["one", "two", "three"]
 }
 `
@@ -53,12 +53,12 @@ func TestSmallDataSourceManyChunks(t *testing.T) {
 			{
 				Config: testSmallDataSourceManyChunksConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.%", "2"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.#", "2"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.1.#", "1"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.0", "one"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.0.1", "two"),
-					resource.TestCheckResourceAttr("data.split-policies.test", "chunks.1.0", "three"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.%", "2"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.0.#", "2"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.1.#", "1"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.0.0", "one"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.0.1", "two"),
+					resource.TestCheckResourceAttr("data.splitpolicies.test", "chunks.1.0", "three"),
 				),
 			},
 		},
@@ -66,7 +66,7 @@ func TestSmallDataSourceManyChunks(t *testing.T) {
 }
 
 const testSmallDataSourceManyChunksConfig = `
-data "split-policies" "test" {
+data "splitpolicies" "test" {
   policies = ["one", "two", "three"]
   maximum_chunk_size = 6
 }

--- a/internal/provider/hash_inputs.go
+++ b/internal/provider/hash_inputs.go
@@ -15,7 +15,7 @@ func hashInputs(data *TfSplitPoliciesDataSourceModel) (string, error) {
 	var hasher = sha1.New()
 	var err error
 
-	if _, err = hasher.Write([]byte("split-policies")); err != nil {
+	if _, err = hasher.Write([]byte("splitpolicies")); err != nil {
 		return "", err
 	}
 

--- a/internal/provider/hash_inputs_test.go
+++ b/internal/provider/hash_inputs_test.go
@@ -26,7 +26,7 @@ func getTestInputs() *TfSplitPoliciesDataSourceModel {
 func TestHashInputs(t *testing.T) {
 	var value, err = hashInputs(getTestInputs())
 	assert.NoError(t, err)
-	if diff := cmp.Diff("89160751b83d1e981c46598c914b50c870d141f3", value); diff != "" {
+	if diff := cmp.Diff("db41eaa716394bd139c3b009ce47a6be593d2c40", value); diff != "" {
 		t.Errorf("Got invalid hash:\n%s", diff)
 	}
 }
@@ -34,7 +34,7 @@ func TestHashInputs(t *testing.T) {
 func TestEmptyHashInputs(t *testing.T) {
 	var value, err = hashInputs(getEmptyTestInputs())
 	assert.NoError(t, err)
-	if diff := cmp.Diff("e7607a63a2af79a17a07d6aec52471436b72a363", value); diff != "" {
+	if diff := cmp.Diff("f3d7f7ba5e397bbe8ea00a989a1a746d5dfe7f91", value); diff != "" {
 		t.Errorf("Got invalid hash:\n%s", diff)
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,7 +27,7 @@ func (p *TfSplitPoliciesProvider) Metadata(
 	_ context.Context,
 	_ provider.MetadataRequest,
 	resp *provider.MetadataResponse) {
-	resp.TypeName = "split-policies"
+	resp.TypeName = "splitpolicies"
 	resp.Version = p.version
 }
 
@@ -64,7 +64,7 @@ func (*TfSplitPoliciesProvider) DataSources(_ context.Context) []func() datasour
 	}
 }
 
-// New creates a new tf-split-policies provider
+// New creates a new tf-splitpolicies provider
 func New(version string) func() provider.Provider {
 	return func() provider.Provider {
 		return &TfSplitPoliciesProvider{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -12,7 +12,7 @@ import (
 // CLI command executed to create a provider server to which the CLI can
 // reattach.
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"split-policies": providerserver.NewProtocol6WithError(New("test")()),
+	"splitpolicies": providerserver.NewProtocol6WithError(New("test")()),
 }
 
 func testAccPreCheck(_ *testing.T) {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/octoenergy/tf-split-policies/internal/provider"
+	"github.com/octoenergy/terraform-provider-splitpolicies/internal/provider"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -36,7 +36,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "registry.terraform.io/hashicorp/tf-split-policies",
+		Address: "registry.terraform.io/hashicorp/splitpolicies",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
Prior to this change, we were getting Error while attempting to publish provider: : invalid provider name when trying to publish in TF cloud. This should fix that problem.