### PR TITLE
Schema: remove Computed from data source attributes

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -26,7 +26,6 @@ type TfSplitPoliciesDataSource struct {
 
 // TfSplitPoliciesDataSourceModel describes the data source data model.
 type TfSplitPoliciesDataSourceModel struct {
-	ID               types.String   `tfsdk:"id"`
 	MaximumChunkSize types.Int64    `tfsdk:"maximum_chunk_size"`
 	Hash             types.String   `tfsdk:"hash"`
 	Policies         []types.String `tfsdk:"policies"`
@@ -51,7 +50,6 @@ func (*TfSplitPoliciesDataSource) Schema(
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Splitting multiple JSON AWS policies into chunks of a given maximum size",
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{},
 			"hash": schema.StringAttribute{
 				MarkdownDescription: "The hash of all the inputs, usefull for update triggering",
 			},
@@ -139,7 +137,6 @@ func (*TfSplitPoliciesDataSource) Read(
 	}
 
 	data.Chunks = mv
-	data.ID = types.StringValue("some-id")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -51,16 +51,12 @@ func (*TfSplitPoliciesDataSource) Schema(
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Splitting multiple JSON AWS policies into chunks of a given maximum size",
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed: true,
-			},
+			"id": schema.StringAttribute{},
 			"hash": schema.StringAttribute{
 				MarkdownDescription: "The hash of all the inputs, usefull for update triggering",
-				Computed:            true,
 			},
 			"chunks": schema.MapAttribute{
 				ElementType: chunksType,
-				Computed:    true,
 			},
 			"policies": schema.ListAttribute{
 				ElementType: types.StringType,


### PR DESCRIPTION
## WHAT

 - Changes `Computed` back to `false` (default value) for attributes on the data source.
 - Removes `ID` as it's [unused](https://github.com/search?q=org%3Aoctoenergy+%2Fsplitpolicies.*%5C.%28id%7Cchunks%29%2F&type=code), and conflicts with this change due to leaving ID without any values set

## WHY

We frequently hit this issue:
https://spacelift.ktl.net/stack/oejp-test/run/01JGX3WPZKHSF1NV56VHZ08A0T

> │   on ../../application_eks_modules/kraken_policies_creator/main.tf line 16, in data "aws_iam_policy_document" "kraken_core_policy_docs":
> │   16:   for_each                = data.splitpolicies.kraken_core_policy_docs.chunks
> │     ├────────────────
> │     │ data.splitpolicies.kraken_core_policy_docs.chunks is a map of list of string, known only after apply

In part, this is caused by the Computed flag here. Terraform assumes it cannot know the outcome at plan time, so it cannot proceed.

Spiritually, the Compute flag is about telling Terraform when the provider does not know the outcome until after apply. In this case, the outcome is obvious to the provider as it's basically just manipulating the inputs, without any external factors. For that reason, I think Compute should be false. 