### PR TITLE
Auto-approve dependabot PRs

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -1,0 +1,21 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'octoenergy/terraform-provider-splitpolicies'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This will (hopefully) fix several things:
- dependabot needs to be approved or interacted with every once and a while, apparently:
![image](https://github.com/user-attachments/assets/76270193-93a3-44db-a136-d35559401934)

- we have a few advisories that would likely be fixed if dependabot can update: https://github.com/advisories/GHSA-hcg3-q754-cr77/dependabot?query=user%3Aoctoenergy
- We will no longer have to watch this repo as closely for this
---

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#automatically-approving-a-pull-request